### PR TITLE
Update client data to 1.19.62

### DIFF
--- a/src/alvin0319/WaterdogExtraInjector/network/handler/WDPEClientData.php
+++ b/src/alvin0319/WaterdogExtraInjector/network/handler/WDPEClientData.php
@@ -128,6 +128,9 @@ final class WDPEClientData{
 	public bool $ThirdPartyNameOnly;
 
 	/** @required */
+	public bool $TrustedSkin;
+
+	/** @required */
 	public int $UIProfile;
 
 	/** @required */

--- a/src/alvin0319/WaterdogExtraInjector/network/handler/WDPEClientData.php
+++ b/src/alvin0319/WaterdogExtraInjector/network/handler/WDPEClientData.php
@@ -54,6 +54,9 @@ final class WDPEClientData{
 	public int $GuiScale;
 
 	/** @required */
+    	public bool $IsEditorMode = false;
+
+	/** @required */
 	public string $LanguageCode;
 
 	/**

--- a/src/alvin0319/WaterdogExtraInjector/network/handler/WDPEClientData.php
+++ b/src/alvin0319/WaterdogExtraInjector/network/handler/WDPEClientData.php
@@ -59,6 +59,8 @@ final class WDPEClientData{
 	/** @required */
 	public string $LanguageCode;
 
+	public bool $OverrideSkin;
+
 	/**
 	 * @var \pocketmine\network\mcpe\protocol\types\login\ClientDataPersonaSkinPiece[]
 	 * @required


### PR DESCRIPTION
I know this plugin is frowned upon but I still continue to use it so im sure others do as well. 
This pull request updates the client data to match what is required in PMMP Protocol version 1.19.62.

Just a heads up, at the time of this request, the update is not out for Android and Switch. 