### PR TITLE
ProcessLoginTask에서 on_completion callback 함수를 호출할 때 3번째 인자로 Translate 객체도 받도록 수정

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: WaterdogExtraInjector
 author: alvin0319
 main: alvin0319\WaterdogExtraInjector\Loader
-version: 1.0.0
+version: 1.0.1
 api: 5.0.0

--- a/src/alvin0319/WaterdogExtraInjector/Loader.php
+++ b/src/alvin0319/WaterdogExtraInjector/Loader.php
@@ -7,6 +7,7 @@ namespace alvin0319\WaterdogExtraInjector;
 use alvin0319\WaterdogExtraInjector\network\handler\WDPELoginPacketHandler;
 use pocketmine\event\EventPriority;
 use pocketmine\event\server\DataPacketReceiveEvent;
+use pocketmine\lang\Translatable;
 use pocketmine\network\mcpe\NetworkSession;
 use pocketmine\network\mcpe\protocol\LoginPacket;
 use pocketmine\network\PacketHandlingException;
@@ -41,7 +42,7 @@ final class Loader extends PluginBase{
 						/** @noinspection PhpUndefinedMethodInspection */
 						$this->getLogger()->setPrefix($this->getLogPrefix());
 					})->call($event->getOrigin());
-				}, function(bool $isAuthenticated, bool $authRequired, ?string $error, ?string $clientPubKey) use ($event) : void{
+				}, function(bool $isAuthenticated, bool $authRequired, string|Translatable|null $error, ?string $clientPubKey) use ($event) : void{
 					\Closure::bind(
 						closure: function(NetworkSession $session) use ($isAuthenticated, $authRequired, $error, $clientPubKey) : void{
 							$session->setAuthenticationStatus($isAuthenticated, $authRequired, $error, $clientPubKey);


### PR DESCRIPTION
PocketMine-MP Crash Dump Sun Sep 29 01:14:51 KST 2024

PocketMine-MP version: 5.19.0 [Protocol 729]
Git commit: 49c2f13cf01c045eaba55553f1907cd30ba4e550
PHP version: 8.3.4
OS: Linux, linux

THIS CRASH WAS CAUSED BY A PLUGIN
BAD PLUGIN: WaterdogExtraInjector

Thread: Main
Error: alvin0319\WaterdogExtraInjector\Loader::alvin0319\WaterdogExtraInjector\{closure}(): Argument #3 ($error) must be of type ?string, pocketmine\lang\Translatable given, called in phar:///tmp/PocketMine-MP-phar-cache.0/PMMPk2IjMK.tar/src/network/mcpe/auth/ProcessLoginTask.php on line 211
File: plugins/WaterdogExtraInjector_v1.0.0/src/alvin0319/WaterdogExtraInjector/Loader
Line: 44
Type: TypeError
Backtrace:
#0 pmsrc/src/network/mcpe/auth/ProcessLoginTask(211): alvin0319\WaterdogExtraInjector\Loader->alvin0319\WaterdogExtraInjector\{closure}(false, false, object pocketmine\lang\Translatable#1122447, null)
#1 pmsrc/src/scheduler/AsyncPool(280): pocketmine\network\mcpe\auth\ProcessLoginTask->onCompletion()
#2 pmsrc/src/timings/TimingsHandler(198): pocketmine\scheduler\AsyncPool->pocketmine\scheduler\{closure}()
#3 pmsrc/src/scheduler/AsyncPool(279): pocketmine\timings\TimingsHandler->time(object Closure#518302)
#4 pmsrc/src/scheduler/AsyncPool(127): pocketmine\scheduler\AsyncPool->collectTasksFromWorker(int 0)
#5 pmsrc/src/TimeTrackingSleeperHandler(58): pocketmine\scheduler\AsyncPool->pocketmine\scheduler\{closure}()
#6 pmsrc/vendor/pocketmine/snooze/src/SleeperHandler(120): pocketmine\TimeTrackingSleeperHandler->pocketmine\{closure}()
#7 pmsrc/src/TimeTrackingSleeperHandler(77): pocketmine\snooze\SleeperHandler->processNotifications()
#8 pmsrc/vendor/pocketmine/snooze/src/SleeperHandler(79): pocketmine\TimeTrackingSleeperHandler->processNotifications()
#9 pmsrc/src/Server(1698): pocketmine\snooze\SleeperHandler->sleepUntil(float 1727540091.8617)
#10 pmsrc/src/Server(1066): pocketmine\Server->tickProcessor()
#11 pmsrc/src/PocketMine(355): pocketmine\Server->__construct(object pocketmine\thread\ThreadSafeClassLoader#6, object pocketmine\utils\MainLogger#2, string[16] /home/container/, string[24] /home/container/plugins/)
#12 pmsrc/src/PocketMine(378): pocketmine\server()
#13 /home/container/PocketMine-MP.phar(168): require(string[72] phar:///tmp/PocketMine-MP-phar-cache.0/PMMPk2IjMK.tar/src/PocketMine.php)

Resolve this crash.